### PR TITLE
chore: set up tooling baseline and package skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,35 @@
 .idea/
 *.iml
 misc.xml
+
+# Python
+__pycache__/
+.pytest_cache/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+
+# Virtual environments and uv
+.venv/
+venv/
+.uv/
+.uv_cache/
+
+# Node
+node_modules/
+.next/
+*.log
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+
+# OS / Editor junk
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
-nodejs 24.5.0
 python 3.13.6
+nodejs 24.5.0
 terraform 1.12.2
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# bugbox
+
+## Tooling Setup
+
+- Python 3.13.6
+- Node.js 24.5.0
+- Terraform 1.12.2
+
+The Python package lives in [`bugbox/`](bugbox/) and uses [uv](https://github.com/astral-sh/uv) for development. See the [Tech Baseline](context/Tech%20Baseline.md) for more details.
+

--- a/bugbox/pyproject.toml
+++ b/bugbox/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "bugbox"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = []
+

--- a/context/Tech Baseline.md
+++ b/context/Tech Baseline.md
@@ -1,0 +1,31 @@
+# Tech Baseline
+
+## Runtime Versions
+
+- Python 3.13.6
+- Node.js 24.5.0
+- Terraform 1.12.2
+
+## Tooling
+
+The Python package in `bugbox/` uses [uv](https://github.com/astral-sh/uv) for environment management, locking, building, and publishing.
+
+## Folder Intent
+
+- `bugbox/` – PyPI package (CLI, decorator, core logic)
+- `frontend/` – Next.js site (later)
+- `backend/` – API layer (infra-agnostic; Cloudflare Worker today)
+- `context/` – internal project docs
+
+## Local Development
+
+Sync the environment in `bugbox/` using `uv sync`.
+
+## Continuous Integration
+
+CI will run Python 3.13 and use uv within `bugbox/`.
+
+## Versioning
+
+Versioning policy will be defined in a later ticket.
+


### PR DESCRIPTION
## Summary
- add `bugbox/` package directory with empty `tests/`
- initialize uv project inside `bugbox/`
- document runtime/tooling baseline and update repo ignores & README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae6512a3b4832181f270d2b915f860